### PR TITLE
Remove scripts for managing test db added on previous PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,15 +6,12 @@
   "scripts": {
     "compose:up": "dotenv -e .env.dev -e .env.test -- docker-compose up -d",
     "compose:down": "dotenv -e .env.dev -e .env.test -- docker-compose down",
-    "db:setup": "npm run migrate:dev && npm run migrate:test",
+    "db:setup": "npm run migrate:dev",
     "dev": "dotenv -e .env.dev -- tsnd --respawn src/server.ts",
     "lint": "eslint --fix . --ext .ts",
-    "migrate:dev": "dotenv -e .env.dev -- prisma migrate dev",
-    "migrate:test": "dotenv -e .env.test -- prisma migrate dev",
-    "migrate:reset:dev": "dotenv -e .env.dev -- prisma migrate reset",
-    "migrate:reset:test": "dotenv -e .env.test -- prisma migrate reset",
-    "seed:dev": "dotenv -e .env.dev -- prisma db seed",
-    "seed:test": "dotenv -e .env.test -- prisma db seed",
+    "migrate": "dotenv -e .env.dev -- prisma migrate dev",
+    "migrate:reset": "dotenv -e .env.dev -- prisma migrate reset",
+    "seed": "dotenv -e .env.dev -- prisma db seed",
     "test": "dotenv -e .env.test -- jest"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "compose:up": "dotenv -e .env.dev -e .env.test -- docker-compose up -d",
     "compose:down": "dotenv -e .env.dev -e .env.test -- docker-compose down",
-    "db:setup": "npm run migrate:dev",
     "dev": "dotenv -e .env.dev -- tsnd --respawn src/server.ts",
     "lint": "eslint --fix . --ext .ts",
     "migrate": "dotenv -e .env.dev -- prisma migrate dev",


### PR DESCRIPTION
There's no need to manage the test db as it's going to be managed by the tests themselves.